### PR TITLE
Add generic porting plan template

### DIFF
--- a/generic-porting-plan.md
+++ b/generic-porting-plan.md
@@ -1,0 +1,59 @@
+# A5 Generic Porting Plan Template
+
+This template outlines the steps required to port the A5 geospatial indexing library to another programming language. Replace **<LANGUAGE>** with the target language and update any environment‑specific notes as needed.
+
+## 1. Environment Setup
+
+1. Install or configure a modern development toolchain for **<LANGUAGE>**.
+2. Ensure numerical libraries (for vectors, matrices, quaternions) are available or prepare lightweight equivalents.
+3. Decide on a project structure that mirrors the module layout in the TypeScript implementation.
+
+## 2. Core Modules to Implement
+
+The library can be ported module by module. Follow the order below since later components build on earlier utilities.
+
+1. **Mathematical Utilities**
+   - Functions for degree/radian conversions and coordinate transformations.
+   - Conversions between Cartesian, spherical, and custom coordinate systems.
+   - Helpers for mapping points to pentagon faces (`toFace`, `FaceToIJ`, `IJToFace`, etc.).
+2. **Warping and Projection Utilities**
+   - Angle normalization and area‐preserving warp.
+   - Gnomonic projection and its inverse between polar and spherical coordinates.
+   - Combination of the above for projecting between planar pentagons and the sphere.
+3. **Dodecahedron Origins**
+   - Define the 12 face origins with orientation and rotation data.
+   - Implement Hilbert curve helpers for moving between quintants and segments.
+4. **Pentagon Geometry and Tiling**
+   - Define the pentagon shape and basis vectors.
+   - Construct pentagon vertices for a given resolution and apply flips/offsets.
+5. **Hilbert Curve Conversion**
+   - Convert between Hilbert curve indices and lattice coordinates, respecting orientation.
+   - Provide helpers for deriving anchor offsets and computing indices.
+6. **Serialization Format**
+   - Encode cell identifiers as 64‑bit integers (or language equivalent).
+   - Implement `serialize`, `deserialize`, and hierarchy operations (parent/child).
+7. **Cell Operations**
+   - Convert geographic coordinates to cell identifiers and back.
+   - Build pentagon boundaries and hit tests for point containment.
+   - Provide boundary and center retrieval in longitude/latitude.
+8. **Hexadecimal Conversion**
+   - Optional utilities for hex string encoding/decoding of cell IDs.
+9. **Public API Entry Point**
+   - Expose the functions above as a cohesive API for **<LANGUAGE>** projects.
+   - Ensure exports and typing/metadata match conventions of **<LANGUAGE>**.
+
+## 3. Usage Examples and Testing
+
+1. Recreate CLI or application examples in **<LANGUAGE>** to verify functionality.
+2. Translate existing unit tests or create new ones to cover key algorithms.
+3. Validate correctness by comparing against the TypeScript implementation or known outputs.
+
+## 4. Deployment Considerations
+
+1. Package the library for distribution according to **<LANGUAGE>** standards.
+2. Provide documentation for installation and usage in the new environment.
+3. Maintain parity with future updates of the TypeScript version when possible.
+
+---
+
+Use this document as a starting point for your port. Adapt terminology and tooling details as necessary for the target language and its ecosystem.


### PR DESCRIPTION
## Summary
- provide a `generic-porting-plan.md` with common steps for porting A5 to any language

## Testing
- `yarn test` *(fails: project not installed)*